### PR TITLE
Bootstrap 4 Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # bootstrap-year-calendar
-A fully customizable year calendar widget, for boostrap !
+A fully customizable year calendar widget, now for Bootstrap 4 !
 You can find all details on the [official website](http://www.bootstrap-year-calendar.com/).
 
 
@@ -8,7 +8,7 @@ You can find all details on the [official website](http://www.bootstrap-year-cal
 ## Requirements
 
 This plugin requires the following libraries :
-- Bootstrap v3.0.0 or later
+- Bootstrap v4.0.0 or later
 - jQuery v1.8.0 or later
 
 ## Installation

--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
   ],
   "license": "Apache-2.0",
   "dependencies": {
-    "bootstrap": ">=3.1.1",
+    "bootstrap-v4-dev": ">=4.0.0",
     "jquery": ">=1.8.2",
     "open-iconic": ">=1.1.1"
   },

--- a/bower.json
+++ b/bower.json
@@ -7,7 +7,8 @@
   "license": "Apache-2.0",
   "dependencies": {
     "bootstrap": ">=3.1.1",
-    "jquery": ">=1.8.2"
+    "jquery": ">=1.8.2",
+    "open-iconic": ">=1.1.1"
   },
   "ignore": []
 }

--- a/css/bootstrap-year-calendar.css
+++ b/css/bootstrap-year-calendar.css
@@ -121,7 +121,7 @@
 
 .calendar .month-container {
 	text-align:center;
-	height:200px;
+	/*height:200px;*/
 	padding:0;
 }
 

--- a/js/bootstrap-year-calendar.js
+++ b/js/bootstrap-year-calendar.js
@@ -114,7 +114,7 @@
 			}
 			
 			var prevIcon = $(document.createElement('span'));
-			prevIcon.addClass('glyphicon glyphicon-chevron-left');
+			prevIcon.addClass('oi oi-chevron-left');
 			
 			prevDiv.append(prevIcon);
 			
@@ -174,7 +174,7 @@
 			}
 			
 			var nextIcon = $(document.createElement('span'));
-			nextIcon.addClass('glyphicon glyphicon-chevron-right');
+			nextIcon.addClass('oi oi-chevron-right');
 			
 			nextDiv.append(nextIcon);
 			
@@ -705,7 +705,7 @@
 				eventItem.append(eventItemContent);
 				
 				var icon = $(document.createElement('span'));
-				icon.addClass('glyphicon glyphicon-chevron-right');
+				icon.addClass('oi oi-chevron-right');
 				
 				eventItem.append(icon);
 				
@@ -749,7 +749,7 @@
 					}
 					
 					var icon = $(document.createElement('span'));
-					icon.addClass('glyphicon glyphicon-chevron-right');
+					icon.addClass('oi oi-chevron-right');
 					
 					menuItem.append(icon);
 					

--- a/js/bootstrap-year-calendar.js
+++ b/js/bootstrap-year-calendar.js
@@ -189,6 +189,11 @@
 		_renderBody: function() {
 			var monthsDiv = $(document.createElement('div'));
 			monthsDiv.addClass('months-container');
+
+			var bsRow = $(document.createElement('div'));
+			bsRow.addClass('row m-0');
+
+			monthsDiv.append(bsRow);
 			
 			for(var m = 0; m < 12; m++) {
 				/* Container */
@@ -307,7 +312,7 @@
 				
 				monthDiv.append(table);
 				
-				monthsDiv.append(monthDiv);
+				bsRow.append(monthDiv);
 			}
 			
 			this.element.append(monthsDiv);
@@ -625,19 +630,19 @@
 				var monthContainerClass = 'month-container';
 				
 				if(monthSize * 6 < calendarSize) {
-					monthContainerClass += ' col-xs-2';
+					monthContainerClass += ' col-2';
 				}
 				else if(monthSize * 4 < calendarSize) {
-					monthContainerClass += ' col-xs-3';
+					monthContainerClass += ' col-3';
 				}
 				else if(monthSize * 3 < calendarSize) {
-					monthContainerClass += ' col-xs-4';
+					monthContainerClass += ' col-4';
 				}
 				else if(monthSize * 2 < calendarSize) {
-					monthContainerClass += ' col-xs-6';
+					monthContainerClass += ' col-6';
 				}
 				else {
-					monthContainerClass += ' col-xs-12';
+					monthContainerClass += ' col-12';
 				}
 				
 				$(_this.element).find('.month-container').attr('class', monthContainerClass);

--- a/js/bootstrap-year-calendar.js
+++ b/js/bootstrap-year-calendar.js
@@ -2,6 +2,8 @@
  * Bootstrap year calendar v1.1.0
  * Repo: https://github.com/Paul-DS/bootstrap-year-calendar
  * =========================================================
+ * BOOTSTRAP 4 Integration by Raul Neiva
+ * =========================================================
  * Created by Paul David-Sivelle
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -97,7 +99,10 @@
 		},
 		_renderHeader: function() {
 			var header = $(document.createElement('div'));
-			header.addClass('calendar-header panel panel-default');
+			header.addClass('calendar-header card');
+
+			var headerBody = $(document.createElement('div'));
+			headerBody.addClass('card-body p-0');
 			
 			var headerTable = $(document.createElement('table'));
 			
@@ -175,7 +180,9 @@
 			
 			headerTable.append(nextDiv);
 			
-			header.append(headerTable);
+			headerBody.append(headerTable);
+
+			header.append(headerBody);
 			
 			this.element.append(header);
 		},

--- a/js/bootstrap-year-calendar.js
+++ b/js/bootstrap-year-calendar.js
@@ -121,7 +121,7 @@
 			headerTable.append(prevDiv);
 			
 			var prev2YearDiv = $(document.createElement('th'));
-			prev2YearDiv.addClass('year-title year-neighbor2 hidden-sm hidden-xs');
+			prev2YearDiv.addClass('year-title year-neighbor2 d-none d-md-table-cell');
 			prev2YearDiv.text(this.options.startYear - 2);
 			
 			if(this.options.minDate != null && this.options.minDate > new Date(this.options.startYear - 2, 11, 31)) {
@@ -131,7 +131,7 @@
 			headerTable.append(prev2YearDiv);
 			
 			var prevYearDiv = $(document.createElement('th'));
-			prevYearDiv.addClass('year-title year-neighbor hidden-xs');
+			prevYearDiv.addClass('year-title year-neighbor d-none d-sm-table-cell');
 			prevYearDiv.text(this.options.startYear - 1);
 			
 			if(this.options.minDate != null && this.options.minDate > new Date(this.options.startYear - 1, 11, 31)) {
@@ -147,7 +147,7 @@
 			headerTable.append(yearDiv);
 			
 			var nextYearDiv = $(document.createElement('th'));
-			nextYearDiv.addClass('year-title year-neighbor hidden-xs');
+			nextYearDiv.addClass('year-title year-neighbor d-none d-sm-table-cell');
 			nextYearDiv.text(this.options.startYear + 1);
 			
 			if(this.options.maxDate != null && this.options.maxDate < new Date(this.options.startYear + 1, 0, 1)) {
@@ -157,7 +157,7 @@
 			headerTable.append(nextYearDiv);
 			
 			var next2YearDiv = $(document.createElement('th'));
-			next2YearDiv.addClass('year-title year-neighbor2 hidden-sm hidden-xs');
+			next2YearDiv.addClass('year-title year-neighbor2 d-none d-md-table-cell');
 			next2YearDiv.text(this.options.startYear + 2);
 			
 			if(this.options.maxDate != null && this.options.maxDate < new Date(this.options.startYear + 2, 0, 1)) {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "homepage": "http://www.bootstrap-year-calendar.com/",
   "dependencies": {
     "bootstrap": ">=3.1.1",
-    "jquery": ">=1.8.2"
+    "jquery": ">=1.8.2",
+    "open-icon": ">=1.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "http://www.bootstrap-year-calendar.com/",
   "dependencies": {
-    "bootstrap": ">=3.1.1",
+    "bootstrap-v4-dev": ">=4.0.0",
     "jquery": ">=1.8.2",
     "open-iconic": ">=1.1.1"
   }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,6 @@
   "dependencies": {
     "bootstrap": ">=3.1.1",
     "jquery": ">=1.8.2",
-    "open-icon": ">=1.1.1"
+    "open-iconic": ">=1.1.1"
   }
 }


### PR DESCRIPTION
Migrated BS3 classes to BS4 classes
+ .panel -> .card
+ .row wrapper for .col
+ .col no longer needs breakpoints
+ .hidden-* is deprecated, used d-* for the year header

Icons are handled by external dependency **open-iconic**, recommended by Bootstrap 4 ([https://getbootstrap.com/docs/4.0/extend/icons/](https://getbootstrap.com/docs/4.0/extend/icons/)).