### PR TITLE
fix(bootstrap-year-calendar.d.ts) fix bug with typing for jquery

### DIFF
--- a/typescript/bootstrap-year-calendar.d.ts
+++ b/typescript/bootstrap-year-calendar.d.ts
@@ -3,7 +3,7 @@
 // Definitions by: Paul David-Sivelle
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
-/// <reference path="../jquery/jquery.d.ts"/>
+/// <reference types="jquery"/>
 
 /**
  * Represent a context menu item for the calendar.


### PR DESCRIPTION
Now there is a problem with tsc compiling:
node_modules/bootstrap-year-calendar/typescript/bootstrap-year-calendar.d.ts(6,22): error TS6053: File '<YOUR_FOLDER>/node_modules/bootstrap-year-calendar/jquery/jquery.d.ts' not found.

So this pull request inserts /// <reference types="..." /> directive and we have a reference to jquery package instead of jquery.d.ts declarations file.